### PR TITLE
app: Move backward-compat logic into get_trigger_metadata

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -94,17 +94,9 @@ impl TriggerExecutor for HttpTrigger {
 
     async fn new(engine: TriggerAppEngine<Self>) -> Result<Self> {
         let mut base = engine
-            .app()
-            .get_metadata(spin_http::trigger::METADATA_KEY)?
-            .map_or_else(
-                || {
-                    engine
-                        .trigger_metadata::<spin_http::trigger::Metadata>()
-                        .unwrap_or_default()
-                        .map_or(String::new(), |f| f.base)
-                },
-                |t| t.base,
-            );
+            .trigger_metadata::<spin_http::trigger::Metadata>()?
+            .unwrap_or_default()
+            .base;
 
         if !base.starts_with('/') {
             base = format!("/{base}");


### PR DESCRIPTION
This moves the "triggers" vs "trigger" logic into App::get_trigger_metadata to ensure other users of `spin-app` get the right values.